### PR TITLE
Removes automatic step-in for `.nest` styles

### DIFF
--- a/lib/index.styl
+++ b/lib/index.styl
@@ -1,3 +1,3 @@
 @import 'spacing'
-@import 'nest'
+@import 'nestle'
 @import 'grid'

--- a/lib/nestle.styl
+++ b/lib/nestle.styl
@@ -36,11 +36,6 @@ nestle(ratio = 1.5, shift = -2.5, steps = 6, dev = false, bg = devColor)
 
     .nest-{step}
 
-      // Adjust spacing size for children
-      rank = steps - ((step + 1) - shift)
-      size = (ratio**rank)
-      size = round(size,3)
-
       *
         margin-top unit(size, em)
         margin-top unit(size, rem)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestle",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A layout system built for Stylus",
   "keywords": [
     "stylus",


### PR DESCRIPTION
I decided to remove this since it's not readily apparent and could cause confusion. If you want to have stepped nesting, simply apply the appropriate level.
